### PR TITLE
Update dart.json

### DIFF
--- a/snippets/dart.json
+++ b/snippets/dart.json
@@ -21,7 +21,7 @@
       "class $1 extends StatefulWidget {",
       "  const $1({super.key});",
       "  @override",
-      "  State<StatefulWidget> createState() => _$1State();",
+      "  State<$1> createState() => _$1State();",
       "}",
       "class _$1State extends State<$1> {",
       "  @override",


### PR DESCRIPTION
Edit the Consumer Stateful widget.

Let's say, when creating a `State` class called `MyHomePage`.

The correct generic type for the `State` class in the `createState` method should be `State<MyHomePage>`, not `State<StatefulWidget>`. 

Therefor, replacing `State<StatefulWidget>` for `State<$1>` (user input).